### PR TITLE
Add docker-dafseq image for the nf-dafseq pipeline

### DIFF
--- a/docker-dafseq/Dockerfile
+++ b/docker-dafseq/Dockerfile
@@ -1,0 +1,33 @@
+FROM dhspence/docker-baseimage:latest
+
+LABEL version="1.0"
+LABEL description="DAF-seq tools: minimap2 + python deps for the nf-dafseq dedup & phasing steps"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The base image already provides samtools, pysam, pandas, numpy, scipy and the UCSC
+# bedGraphToBigWig used by phasing. Add what it lacks for nf-dafseq:
+
+# minimap2 (alignment step), pinned to match the workflow
+ENV MINIMAP2_VERSION=2.30
+RUN cd /opt && \
+    git clone https://github.com/lh3/minimap2 && \
+    cd minimap2 && \
+    git checkout v${MINIMAP2_VERSION} && \
+    make && \
+    cp minimap2 /usr/local/bin/ && \
+    cd /opt && rm -rf minimap2/*.o
+
+# python packages used by the dedup (clustering) and QC plotting that are not in the base image
+RUN pip install --no-cache-dir \
+    scikit-learn \
+    seaborn \
+    matplotlib==3.10.3
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Sanity check: fail the build if anything the pipeline needs is missing
+RUN minimap2 --version && \
+    samtools --version | head -1 && \
+    bedGraphToBigWig 2>&1 | head -1; \
+    python3 -c "import pysam, pandas, numpy, scipy, sklearn, matplotlib, seaborn; print('dafseq py deps OK')"

--- a/docker-dafseq/README.md
+++ b/docker-dafseq/README.md
@@ -1,0 +1,22 @@
+# docker-dafseq
+
+Image with the tools used by the **nf-dafseq** DAF-seq pipeline (alignment, combinatorial
+dedup, and SNP/deletion phasing). Built on `dhspence/docker-baseimage`.
+
+Adds, on top of the base image:
+
+- **minimap2** (pinned to v2.30) for `map-ont` alignment
+- **scikit-learn**, **seaborn**, **matplotlib** (3.10.3) for the dedup clustering and QC plots
+
+The base image already supplies samtools, pysam, pandas, numpy, scipy, and the UCSC
+`bedGraphToBigWig` used to make the phased bigWigs.
+
+Covers nf-dafseq steps 1 (`MINIMAP_ALIGN`), 3 (`MARK_DUPLICATES`), and 4 (`PHASE_READS`).
+Step 2 (the wrapped DAF-QC-SMK Snakemake) ships as its own image — it bundles pixi + Snakemake
+and does not fit this base-image pattern.
+
+## Build
+
+```bash
+docker build -t dhspence/docker-dafseq:latest docker-dafseq
+```


### PR DESCRIPTION
Builds on dhspence/docker-baseimage and adds minimap2 (v2.30) plus the scikit-learn/seaborn/matplotlib packages the DAF-seq dedup and QC plotting need. Base image already provides samtools, pysam, pandas, numpy, scipy and bedGraphToBigWig. Covers nf-dafseq steps 1/3/4.