### PR TITLE
Fix docker-dafseq build: drop matplotlib pin incompatible with py3.8 …

### DIFF
--- a/docker-dafseq/Dockerfile
+++ b/docker-dafseq/Dockerfile
@@ -5,8 +5,8 @@ LABEL description="DAF-seq tools: minimap2 + python deps for the nf-dafseq dedup
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# The base image already provides samtools, pysam, pandas, numpy, scipy and the UCSC
-# bedGraphToBigWig used by phasing. Add what it lacks for nf-dafseq:
+# The base image (python 3.8) already provides samtools, pysam, pandas, numpy, scipy,
+# scikit-learn, matplotlib and the UCSC bedGraphToBigWig used by phasing. Add what it lacks:
 
 # minimap2 (alignment step), pinned to match the workflow
 ENV MINIMAP2_VERSION=2.30
@@ -18,11 +18,10 @@ RUN cd /opt && \
     cp minimap2 /usr/local/bin/ && \
     cd /opt && rm -rf minimap2/*.o
 
-# python packages used by the dedup (clustering) and QC plotting that are not in the base image
-RUN pip install --no-cache-dir \
-    scikit-learn \
-    seaborn \
-    matplotlib==3.10.3
+# seaborn is the only QC-plotting dep missing from the base; install it without pinning.
+# (Do NOT pin matplotlib here: the base image is python 3.8, and matplotlib>=3.6 drops py3.8 —
+# pip would fail. scikit-learn and matplotlib are already present in the base.)
+RUN pip install --no-cache-dir seaborn
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/docker-dafseq/README.md
+++ b/docker-dafseq/README.md
@@ -6,10 +6,12 @@ dedup, and SNP/deletion phasing). Built on `dhspence/docker-baseimage`.
 Adds, on top of the base image:
 
 - **minimap2** (pinned to v2.30) for `map-ont` alignment
-- **scikit-learn**, **seaborn**, **matplotlib** (3.10.3) for the dedup clustering and QC plots
+- **seaborn** for the dedup QC plots (the only plotting dep not already in the base)
 
-The base image already supplies samtools, pysam, pandas, numpy, scipy, and the UCSC
-`bedGraphToBigWig` used to make the phased bigWigs.
+The base image already supplies samtools, pysam, pandas, numpy, scipy, scikit-learn, matplotlib,
+and the UCSC `bedGraphToBigWig` used to make the phased bigWigs.
+
+Published by CI to `ghcr.io/dhslab/docker-dafseq:latest`.
 
 Covers nf-dafseq steps 1 (`MINIMAP_ALIGN`), 3 (`MARK_DUPLICATES`), and 4 (`PHASE_READS`).
 Step 2 (the wrapped DAF-QC-SMK Snakemake) ships as its own image — it bundles pixi + Snakemake
@@ -18,5 +20,5 @@ and does not fit this base-image pattern.
 ## Build
 
 ```bash
-docker build -t dhspence/docker-dafseq:latest docker-dafseq
+docker build -t ghcr.io/dhslab/docker-dafseq:latest docker-dafseq
 ```


### PR DESCRIPTION
…base

The base image (dhspence/docker-baseimage:latest) is python 3.8 and already ships scikit-learn and matplotlib; matplotlib==3.10.3 has no py3.8 wheel, which failed the CI build. Install only seaborn (unpinned) on top of the base.